### PR TITLE
bpo-43542: Add heif/heic formats in mimetypes

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -505,6 +505,8 @@ def _default_mime_types():
         '.jpg'    : 'image/jpeg',
         '.jpe'    : 'image/jpeg',
         '.jpeg'   : 'image/jpeg',
+        '.heic'   : 'image/heic',
+        '.heif'   : 'image/heif',
         '.png'    : 'image/png',
         '.svg'    : 'image/svg+xml',
         '.tiff'   : 'image/tiff',

--- a/Misc/NEWS.d/next/Library/2021-03-20-15-43-25.bpo-43542.6bt2F6.rst
+++ b/Misc/NEWS.d/next/Library/2021-03-20-15-43-25.bpo-43542.6bt2F6.rst
@@ -1,0 +1,1 @@
+``image/heic`` and ``image/heif`` were added to :mod:`mimetypes`.


### PR DESCRIPTION
Add HEIF and HEIC format to list of media types. It has IANA registration.

IANA: https://www.iana.org/assignments/media-types/image/heic
HEIF Github: https://github.com/nokiatech/heif